### PR TITLE
Eliminate the need to manually set UNITY_CHANGEX

### DIFF
--- a/Reporter/Reporter.cs
+++ b/Reporter/Reporter.cs
@@ -1,6 +1,14 @@
 
 
+#if UNITY_CHANGE1 || UNITY_CHANGE2 || UNITY_CHANGE3
+#warning UNITY_CHANGE has been set manually
+#elif UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5 || UNITY_4_6 || UNITY_4_7
 #define UNITY_CHANGE1
+#elif UNITY_5_0 || UNITY_5_1 || UNITY_5_2
+#define UNITY_CHANGE2
+#else
+#define UNITY_CHANGE3
+#endif
 //use UNITY_CHANGE1 for unity older than "unity 5"
 //use UNITY_CHANGE2 for unity 5.0 -> 5.3 
 //use UNITY_CHANGE3 for unity 5.3 (fix for new SceneManger system  )

--- a/Reporter/Test/TestReporter.cs
+++ b/Reporter/Test/TestReporter.cs
@@ -1,5 +1,14 @@
 ﻿
+
+#if UNITY_CHANGE1 || UNITY_CHANGE2 || UNITY_CHANGE3
+#warning UNITY_CHANGE has been set manually
+#elif UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5 || UNITY_4_6 || UNITY_4_7
 #define UNITY_CHANGE1
+#elif UNITY_5_0 || UNITY_5_1 || UNITY_5_2
+#define UNITY_CHANGE2
+#else
+#define UNITY_CHANGE3
+#endif
 //use UNITY_CHANGE1 for unity older than "unity 5"
 //use UNITY_CHANGE2 for unity 5.0 -> 5.3 
 //use UNITY_CHANGE3 for unity 5.3 (fix for new SceneManger system  )


### PR DESCRIPTION
- Automatically selects the right UNITY_CHANGE if it has not been set in the build options.
- Allows setting the UNITY_CHANGEX by hand from project build options with a compile warning