### PR TITLE
Register Reporter object with Undo

### DIFF
--- a/Reporter/Editor/ReporterEditor.cs
+++ b/Reporter/Editor/ReporterEditor.cs
@@ -17,6 +17,9 @@ public class ReporterEditor : Editor
 		Reporter reporter = reporterObj.AddComponent<Reporter>();
 		reporterObj.AddComponent<ReporterMessageReceiver>();
 		//reporterObj.AddComponent<TestReporter>();
+		
+		// Register root object for undo.
+		Undo.RegisterCreatedObjectUndo(reporterObj, "Create Reporter Object");
 
 		MonoScript reporterScript = MonoScript.FromMonoBehaviour(reporter);
 		string reporterPath = Path.GetDirectoryName(AssetDatabase.GetAssetPath(reporterScript));


### PR DESCRIPTION
Registering the creation of the Reporter game object allows the editor to undo the creation as well as sets the scene as dirty allowing you to save the scene